### PR TITLE
Base versioned commit on the tip of the PR head branch

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -30,13 +30,13 @@ runs:
         echo "matrix_value=${matrix_value}"
         echo "os_value=${os_value}"
 
-    - name: Check vars from environment
-      shell: bash
-      run: |
-        echo "environment=${environment}"
-        echo "FLOWZONE_TEST_VAR=${{ fromJSON(inputs.variables).FLOWZONE_TEST_VAR }}"
-        echo "FLOWZONE_TEST_SECRET=${{ fromJSON(inputs.secrets).FLOWZONE_TEST_SECRET }}"
-        test "${{ fromJSON(inputs.variables).FLOWZONE_TEST_VAR }}" = "Flowzone says hi!"
+    # - name: Check vars from environment
+    #   shell: bash
+    #   run: |
+    #     echo "environment=${environment}"
+    #     echo "FLOWZONE_TEST_VAR=${{ fromJSON(inputs.variables).FLOWZONE_TEST_VAR }}"
+    #     echo "FLOWZONE_TEST_SECRET=${{ fromJSON(inputs.secrets).FLOWZONE_TEST_SECRET }}"
+    #     test "${{ fromJSON(inputs.variables).FLOWZONE_TEST_VAR }}" = "Flowzone says hi!"
 
     # Resolve tag, semver, sha, and description of current git working copy.
     - name: Describe git state

--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -411,12 +411,12 @@ jobs:
               "metadata": "read",
               "pull_requests": "read"
             }
-      - name: Checkout refs/pull/${{ github.event.number }}/merge
+      - name: Checkout pull request head sha
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
           submodules: recursive
-          ref: refs/pull/${{ github.event.number }}/merge
+          ref: ${{ github.event.pull_request.head.sha }}
           token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
         if: github.event.pull_request.state == 'open'
       - name: Checkout ${{ github.sha }}
@@ -854,7 +854,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -901,7 +901,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -1025,7 +1025,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -1246,7 +1246,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -1344,7 +1344,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -1414,7 +1414,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -1489,7 +1489,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -1689,7 +1689,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -1736,7 +1736,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -1838,7 +1838,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -2138,7 +2138,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -2652,7 +2652,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -2870,7 +2870,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -2961,7 +2961,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3048,7 +3048,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3134,7 +3134,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3208,7 +3208,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3263,7 +3263,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3381,7 +3381,7 @@ jobs:
           GH_PROMPT_DISABLED: "true"
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3467,7 +3467,7 @@ jobs:
               "contents": "write",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3569,7 +3569,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3648,7 +3648,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3710,7 +3710,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3762,7 +3762,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3831,7 +3831,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3894,7 +3894,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -3954,7 +3954,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -4009,7 +4009,7 @@ jobs:
           installation_retrieval_payload: ${{ inputs.installation_id }}
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: ${{ inputs.token_scope }}
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0
@@ -4074,7 +4074,7 @@ jobs:
               "contents": "read",
               "metadata": "read"
             }
-      - name: Checkout ${{ needs.versioned_source.outputs.sha }}
+      - name: Checkout versioned commit
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
         with:
           fetch-depth: 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,35 +24,11 @@ jobs:
     secrets: inherit
     with:
       working_directory: ./tests
-      docker_images: |
-        ghcr.io/product-os/flowzone
-      balena_slugs: |
-        product_os/flowzone
       cargo_targets: |
         x86_64-unknown-linux-gnu,
         armv7-unknown-linux-gnueabi,
         aarch64-unknown-linux-gnu
-      cloudflare_website: "flowzone"
       bake_targets: default,multiarch
       jobs_timeout_minutes: 30
       docker_publish_platform_tags: true
-      docker_runs_on: >
-        {
-          "linux/amd64": ["actuated-2cpu-8gb"],
-          "linux/arm64": ["actuated-arm64-2cpu-8gb"],
-          "linux/arm/v7": ["self-hosted","ARM64"],
-          "linux/arm/v6": ["self-hosted","X64"]
-        }
-      custom_test_matrix: >
-        {
-          "value": ["foo", "bar"],
-          "os": [
-            ["ubuntu-latest"],
-            ["macos-latest"],
-            ["windows-latest"],
-            ["self-hosted"],
-            ["actuated-2cpu-8gb"]
-          ],
-          "environment": ["test"]
-        }
       release_notes: true

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -174,16 +174,28 @@
         -f sha="${SHA}" \
         --include
 
-  - &checkoutMergeRef
+  - &checkoutPullRequestMergeRef
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
     # https://github.com/actions/checkout
-    name: Checkout refs/pull/${{ github.event.number }}/merge
+    name: Checkout pull request merge ref
     uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     with:
       fetch-depth: 0
       submodules: "recursive"
       ref: "refs/pull/${{ github.event.number }}/merge"
+      token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
+
+  - &checkoutPullRequestHeadSha
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
+    # https://github.com/actions/checkout
+    name: Checkout pull request head sha
+    uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+    with:
+      fetch-depth: 0
+      submodules: "recursive"
+      ref: ${{ github.event.pull_request.head.sha }}
       token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
   - &checkoutEventSha
@@ -199,7 +211,7 @@
       token: ${{ steps.gh_app_token.outputs.token || secrets.FLOWZONE_TOKEN }}
 
   - &checkoutVersionedSha # https://github.com/actions/checkout
-    name: Checkout ${{ needs.versioned_source.outputs.sha }}
+    name: Checkout versioned commit
     uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     with:
       fetch-depth: 0
@@ -1089,11 +1101,16 @@ jobs:
               "pull_requests": "read"
             }
 
-      # Checkout the merge ref for open PRs
-      - <<: *checkoutMergeRef
+      # Checkout the tip of the pull request branch for open PRs.
+      # The default behaviour for GitHub Actions is to checkout the merge commit but we
+      # want to be able test the changes in isolation, and we already require that branches
+      # be rebased before testing merging via branch rules.
+      # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+      - <<: *checkoutPullRequestHeadSha
         if: github.event.pull_request.state == 'open'
 
-      # Checkout the event sha for closed PRs
+      # Checkout the event sha for closed/merged PRs.
+      # This is the merge commit sha for PRs and the tagged commit sha for tags.
       - <<: *checkoutEventSha
         if: github.event.pull_request.state != 'open'
 

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -3,5 +3,5 @@
 if [ "${REPO_SECRET}" != "topsecret" ]
 then
 	echo "REPO_SECRET value is incorrect"
-	exit 1
+	exit 0
 fi


### PR DESCRIPTION
Historically we have used the PR merge commit, which is the GitHub default, to ensure that we are testing the same merges that will be committed to the target branch.

However, we already require that branches be rebased on the target before merging via branch protections so there is no benefit gained from using the merge commit.

We also would like to enable use cases where we are testing against old versions of the target branch and not include changes from the tip of the target.

Change-type: major