### PR TITLE
Unset permissions from the calling workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,8 @@ jobs:
       working_directory: ./tests
       # docker_images: |
       #   ghcr.io/product-os/flowzone
-      balena_slugs: |
-        product_os/flowzone
+      # balena_slugs: |
+      #   product_os/flowzone
       cargo_targets: |
         x86_64-unknown-linux-gnu,
         armv7-unknown-linux-gnueabi,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,8 +49,8 @@ jobs:
     secrets: inherit
     with:
       working_directory: ./tests
-      docker_images: |
-        ghcr.io/product-os/flowzone
+      # docker_images: |
+      #   ghcr.io/product-os/flowzone
       balena_slugs: |
         product_os/flowzone
       cargo_targets: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,22 +16,22 @@ on:
 # Exceptions need to be provided in the calling workflow with the permissions below + the noted permission increase.
 # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#permissions
-permissions:
-  actions: none
-  attestations: none
-  checks: none
-  contents: read
-  deployments: none
-  id-token: none # AWS GitHub OIDC provider
-  issues: none
-  discussions: read
-  # packages: read
-  packages: write # Allow Flowzone to publish to ghcr.io
-  pages: none
-  pull-requests: none
-  repository-projects: none
-  security-events: none
-  statuses: none
+# permissions:
+#   actions: none
+#   attestations: none
+#   checks: none
+#   contents: read
+#   deployments: none
+#   id-token: none # AWS GitHub OIDC provider
+#   issues: none
+#   discussions: read
+#   # packages: read
+#   packages: write # Allow Flowzone to publish to ghcr.io
+#   pages: none
+#   pull-requests: none
+#   repository-projects: none
+#   security-events: none
+#   statuses: none
 
 jobs:
   flowzone:


### PR DESCRIPTION
This is a test to see if Flowzone is able to run
in an org with the restricted "read-only" default
actions policy.

See: https://balena.fibery.io/Work/Improvement/Change-default-automatic-GITHUB_TOKEN-permissions-scope-to-restricted-in-our-Enterprise-2195