### PR TITLE
Remove admin:write from the versioning token scopes

### DIFF
--- a/.github/workflows/flowzone.yml
+++ b/.github/workflows/flowzone.yml
@@ -118,7 +118,6 @@ on:
         required: false
         default: |-
           {
-            "administration": "write",
             "contents": "write",
             "metadata": "read",
             "packages": "write",
@@ -396,7 +395,6 @@ jobs:
           private_key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           permissions: |-
             {
-              "administration": "write",
               "contents": "write",
               "metadata": "read",
               "pull_requests": "read"

--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ jobs:
       # Required: false
       token_scope: >
         {
-          "administration": "write",
           "contents": "write",
           "metadata": "read",
           "packages": "write",

--- a/flowzone.yml
+++ b/flowzone.yml
@@ -871,7 +871,6 @@ on:
         # https://docs.github.com/en/rest/apps/apps?apiVersion=2022-11-28#create-a-scoped-access-token
         default: >-
           {
-            "administration": "write",
             "contents": "write",
             "metadata": "read",
             "packages": "write",
@@ -1154,11 +1153,9 @@ jobs:
       - <<: *getGitHubAppToken
         with:
           <<: *getGitHubAppTokenWith
-          # administration: write is required to bypass branch protection rules
           # contents: write is required to push git commit and tag references
           permissions: >-
             {
-              "administration": "write",
               "contents": "write",
               "metadata": "read",
               "pull_requests": "read"


### PR DESCRIPTION
With the correct branch rulesets in place we should be able to make exceptions for the app, rather than rely on adminstrator access.

Change-type: minor